### PR TITLE
Fix incorrect content-length header when UTF-8 characters in payload

### DIFF
--- a/StompHelper/StompMessage.cs
+++ b/StompHelper/StompMessage.cs
@@ -41,7 +41,7 @@ namespace StompHelper
             Body = body;
             _headers = headers;
 
-            this["content-length"] = body.Length.ToString();
+            this["content-length"] = Encoding.UTF8.GetBytes(body).Length.ToString();
         }
 
         public Dictionary<string, string> Headers


### PR DESCRIPTION
Fixes an issue where content-length headers are calcualted from string length (number of characters), which is incorrect when payload contains UTF-8 characters with multiple bytes; in our case - emoji.  

The mismatch between content-length header and body length then causes a PROTOCOL_ERROR on the STOMP server, because the frame does not contain the null octet in the expected position. The connection is then terminated.